### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,32 @@ I'm still cooler ngl.
 
 [movie-web.app](https://movie-web.app)
 
-## Mirrors
-
 ✅ = This instance is so trusted I'd give my soul to the owner of it.
 
 ⚡️ = This instance has a chance to be the most recent movie web version (which is good).
 
 💾 = This instance has a backend for syncing data.
 
+🌐 = This instance uses the community backend hosted by Lonelil
+
+📱 = This instance has full Progressive Web App compatibility for mobile.
+
+## Mirrors
 ---
 
-✅⚡ [movie-web-me.vercel.app](https://movie-web-me.vercel.app) - by [Isra](https://github.com/zisra)
+✅⚡💾🌐 [movie-web-me.vercel.app](https://movie-web-me.vercel.app) - by [Isra](https://github.com/zisra)
 
-✅⚡️💾 [mw.lonelil.com](https://mw.lonelil.com) - by [lonelil](https://github.com/lonelil)
+✅⚡️💾🌐📱 [mw.lonelil.com](https://mw.lonelil.com) - by [lonelil](https://github.com/lonelil)
 
-✅⚡💾 [bmov.vercel.app](https://bmov.vercel.app) - by [ScreechingBagel](https://github.com/TheScreechingBagel)
+✅⚡💾🌐 [bmov.vercel.app](https://bmov.vercel.app) - by [ScreechingBagel](https://github.com/TheScreechingBagel)
 
-✅⚡💾 [stream.thehairy.me](https://stream.thehairy.me) - by [thehairy](https://github.com/thehairy)
+✅⚡💾🌐📱 [stream.thehairy.me](https://stream.thehairy.me) - by [thehairy](https://github.com/thehairy)
 
-✅⚡💾 [sudo-flix.lol](https://sudo-flix.lol) - by [itzCozi](https://gitlab.com/itzCozi)
+✅⚡💾🌐📱 [scootydooter.vercel.app](https://scootydooter.vercel.app) - by [Toon](https://github.com/Toon-arch)
 
-✅⚡ [scootydooter.vercel.app](https://scootydooter.vercel.app) - by [Toon](https://github.com/Toon-arch)
+✅⚡💾📱 [sudo-flix.lol](https://sudo-flix.lol) - by [itzCozi](https://gitlab.com/itzCozi)
 
-✅ [watch.lonelil.com](https://watch.lonelil.com) - by [lonelil](https://github.com/lonelil)
-
-✅💾 [mv-web.netlify.app](https://mv-web.netlify.app) - by [qtchaos](https://github.com/qtchaos)
+✅💾📱 [watch.qtchaos.de/](https://watch.qtchaos.de/) - by [qtchaos](https://github.com/qtchaos)
 
 [watchflix.app](https://watchflix.app)
 
@@ -38,8 +39,12 @@ I'm still cooler ngl.
 
 [cloudflare-ipfs@movie-web](https://k51qzi5uqu5diql6nkzokwdvz9511dp9itillc7xhixptq14tk1oz8agh3wrjd.ipns.cf-ipfs.com)
 
-💾 [film.kace.dev](https://film.kace.dev) - by [userkace](https://github.com/userkace)
+💾🌐📱 [film.kace.dev](https://film.kace.dev) - by [userkace](https://github.com/userkace)
 
+---
+## Alternatives
+---
+✅ [watch.lonelil.com](https://watch.lonelil.com) - by [lonelil](https://github.com/lonelil)
 ---
 
 [edit this page](https://github.com/erynith/movie-web-instances/edit/main/README.md) on [github](https://github.com/erynith/movie-web-instances)


### PR DESCRIPTION
Parity with official list at [movie-web.github.io/docs/instances](https://movie-web.github.io/docs/instances).

Added other icons such as PWA and Community Backend identifiers.

Updated [qtchaos](https://github.com/qtchaos)' instance from [mv-web.netlify.app](https://mv-web.netlify.app) to [watch.qtchaos.de/](https://watch.qtchaos.de/) as indicated in the official list.